### PR TITLE
improve install procedure

### DIFF
--- a/install.py
+++ b/install.py
@@ -4,18 +4,17 @@ from modules import scripts
 
 git = os.environ.get('GIT', "git")
 usefulDirs = sys.argv[0].split(os.sep)[-3:]
-print("preinit openOutpaint")
 
-installDir = scripts.basedir() + os.sep + \
-    usefulDirs[0] + os.sep + usefulDirs[1]
+installDir = os.path.join(scripts.basedir(), usefulDirs[0], usefulDirs[1])
 
 # Attempt to use launch module from webui
 command = f'"{git}" -C "' + installDir +\
     '" submodule update --init --recursive --remote'
 try:
     from launch import run
-
-    print(run(command))
+    stdout = run(command)
+    if len(stdout) > 0:
+        print(run(command))
 except ImportError:
     print("[openoutpaint-extension] We failed to import the 'launch' module. Using 'os'")
     os.system(command)

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -1,10 +1,6 @@
-import html
-from modules import script_callbacks, shared, scripts
+from modules import script_callbacks, scripts
 import gradio as gr
-from pathlib import Path
 import os
-import sys
-import platform
 from launch import run
 
 import string
@@ -35,11 +31,6 @@ def add_tab():
 
 
 usefulDirs = scripts.basedir().split(os.sep)[-2:]
-
-print("openOutpaint init")
-git = os.environ.get('GIT', "git")
-print(run(f'"{git}" -C "' + scripts.basedir() +
-      '" submodule update --init --recursive --remote'))
 
 with open(f"{scripts.basedir()}/app/key.json", "w") as keyfile:
     keyfile.write('{\n')


### PR DESCRIPTION
- make `install.py` less verbose on Automatic startup
- print only when needed (using run inside print will print empty line if run reported no errors)
- dont run git updates from both `install.py` and `main.py` - once is enough
